### PR TITLE
Lock down jsonwebtoken dependency

### DIFF
--- a/app/server/models/User.js
+++ b/app/server/models/User.js
@@ -319,11 +319,11 @@ schema.statics.findOneByEmail = function(email){
  * @param  {Function} callback args(err, user)
  */
 schema.statics.getByToken = function(token, callback){
-  jwt.verify(token, JWT_SECRET, function(err, decoded){
+  jwt.verify(token, JWT_SECRET, function(err, id){
     if (err) {
       return callback(err);
     }
-    this.findOne({_id: decoded.id}, callback);
+    this.findOne({_id: id}, callback);
   }.bind(this));
 };
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express": "^4.9.8",
     "gulp-minify-css": "^1.2.0",
     "handlebars": "^3.0.3",
-    "jsonwebtoken": "^5.0.4",
+    "jsonwebtoken": "5.0.4",
     "method-override": "^2.3.5",
     "moment": "^2.10.3",
     "mongoose": "^4.1.2",


### PR DESCRIPTION
Locks down jsonwebtoken dependency and modifies the `schema.statics.getByToken` function in `/app/server/models/User.js` as described in #1 
