### PR TITLE
Update the team view when a team is joined

### DIFF
--- a/app/client/views/team/teamCtrl.js
+++ b/app/client/views/team/teamCtrl.js
@@ -16,13 +16,17 @@ angular.module('reg')
 
       $scope.TEAM = TEAM;
 
-      if ($scope.user.teamCode){
+      function _populateTeammates() {
         UserService
           .getMyTeammates()
           .success(function(users){
             $scope.error = null;
             $scope.teammates = users;
           });
+      }
+
+      if ($scope.user.teamCode){
+        _populateTeammates();
       }
 
       $scope.joinTeam = function(){


### PR DESCRIPTION
When a user joins a team the team information isn't updated on the page. This change implements the _populateTeammates function for both initial load and team join. #20 