### PR TITLE
Show registration/confirmation deadline on dashboard

### DIFF
--- a/app/client/views/dashboard/dashboard.html
+++ b/app/client/views/dashboard/dashboard.html
@@ -60,6 +60,24 @@
         </div>
 
         <div
+          ng-class="settings.timeClose"
+          ng-if="!dashState('admittedAndCanConfirm') || !dashState('admittedAndCannotConfirm') || !dashState('confirmed') || !dashState('declined')">
+          <strong>
+            Registration Deadline:
+          </strong>
+          {{ timeClose }}
+        </div>
+
+        <div
+          ng-class="settings.timeConfirm"
+          ng-if="dashState('admittedAndCanConfirm') || dashState('admittedAndCannotConfirm') || dashState('confirmed') || dashState('declined')">
+          <strong>
+            Confirmation Deadline:
+          </strong>
+          {{ timeConfirm }}
+        </div>
+
+        <div
           ng-if="dashState('openAndIncomplete')"
           class="description">
           <p>

--- a/app/client/views/dashboard/dashboardCtrl.js
+++ b/app/client/views/dashboard/dashboardCtrl.js
@@ -14,9 +14,11 @@ angular.module('reg')
       var Settings = settings.data;
       var user = currentUser.data;
       $scope.user = user;
+      $scope.timeClose = Utils.formatTime(Settings.timeClose);
+      $scope.timeConfirm = Utils.formatTime(Settings.timeConfirm);
 
       $scope.DASHBOARD = DASHBOARD;
-      
+
       for (var msg in $scope.DASHBOARD) {
         if ($scope.DASHBOARD[msg].includes('[APP_DEADLINE]')) {
           $scope.DASHBOARD[msg] = $scope.DASHBOARD[msg].replace('[APP_DEADLINE]', Utils.formatTime(Settings.timeClose));
@@ -81,7 +83,6 @@ angular.module('reg')
       $scope.acceptanceText = $sce.trustAsHtml(converter.makeHtml(Settings.acceptanceText));
       $scope.confirmationText = $sce.trustAsHtml(converter.makeHtml(Settings.confirmationText));
       $scope.waitlistText = $sce.trustAsHtml(converter.makeHtml(Settings.waitlistText));
-
 
       $scope.declineAdmission = function(){
 


### PR DESCRIPTION
Issue #27 
I added the formated dates under the horizontal rule and above the action buttons.


Registration Deadline is shown if the dashState is: `unverified`, `openAndIncomplete`, `openAndSubmitted`, `closedAndIncomplete`, or `closedAndSubmitted`.

Otherwise, the Confirmation Deadline is shown (`admittedAndCanConfirm`, `admittedAndCannotConfirm`, `confirmed`, `declined`).

Example Screenshots:
![confirmation deadline](https://user-images.githubusercontent.com/1291074/29402942-5ffd691c-82fc-11e7-868d-7afed26baeb9.png)
![registrationdeadline](https://user-images.githubusercontent.com/1291074/29402943-5fff392c-82fc-11e7-82f2-2648904a9c43.png)
