### PR TITLE
Admin panel allow minors option

### DIFF
--- a/app/client/src/services/SettingsService.js
+++ b/app/client/src/services/SettingsService.js
@@ -42,7 +42,12 @@ angular.module('reg')
         return $http.put(base + 'confirmation', {
           text: text
         });
-      }
+      },
+      updateAllowMinors: function(allowMinors){
+        return $http.put(base + 'minors', { 
+          allowMinors: allowMinors 
+        });
+      },
     };
 
   }

--- a/app/client/views/admin/settings/adminSettingsCtrl.js
+++ b/app/client/views/admin/settings/adminSettingsCtrl.js
@@ -21,6 +21,22 @@ angular.module('reg')
 
         $scope.settings = settings;
       }
+      
+      // Additional Options --------------------------------------
+
+      $scope.updateAllowMinors = function () {
+        $scope.allowMinors = !$scope.allowMinors;
+
+        SettingsService
+          .updateAllowMinors($scope.allowMinors)
+          .success(function (data) {
+            $scope.settings.allowMinors = data.allowMinors;
+            var successText = $scope.settings.allowMinors ?
+              "Minors are now allowed to register." :
+              "Minors are no longer allowed to register."
+            swal("Looks good!", successText, "success");
+          });
+      };
 
       // Whitelist --------------------------------------
 

--- a/app/client/views/admin/settings/adminSettingsCtrl.js
+++ b/app/client/views/admin/settings/adminSettingsCtrl.js
@@ -25,10 +25,10 @@ angular.module('reg')
       // Additional Options --------------------------------------
 
       $scope.updateAllowMinors = function () {
-        $scope.allowMinors = !$scope.allowMinors;
+        $scope.settings.allowMinors = !$scope.settings.allowMinors;
 
         SettingsService
-          .updateAllowMinors($scope.allowMinors)
+          .updateAllowMinors($scope.settings.allowMinors)
           .success(function (data) {
             $scope.settings.allowMinors = data.allowMinors;
             const successText = $scope.settings.allowMinors ?

--- a/app/client/views/admin/settings/adminSettingsCtrl.js
+++ b/app/client/views/admin/settings/adminSettingsCtrl.js
@@ -31,7 +31,7 @@ angular.module('reg')
           .updateAllowMinors($scope.allowMinors)
           .success(function (data) {
             $scope.settings.allowMinors = data.allowMinors;
-            var successText = $scope.settings.allowMinors ?
+            const successText = $scope.settings.allowMinors ?
               "Minors are now allowed to register." :
               "Minors are no longer allowed to register."
             swal("Looks good!", successText, "success");

--- a/app/client/views/admin/settings/adminSettingsCtrl.js
+++ b/app/client/views/admin/settings/adminSettingsCtrl.js
@@ -25,8 +25,6 @@ angular.module('reg')
       // Additional Options --------------------------------------
 
       $scope.updateAllowMinors = function () {
-        $scope.settings.allowMinors = !$scope.settings.allowMinors;
-
         SettingsService
           .updateAllowMinors($scope.settings.allowMinors)
           .success(function (data) {

--- a/app/client/views/admin/settings/settings.html
+++ b/app/client/views/admin/settings/settings.html
@@ -76,6 +76,27 @@
   </div>
 </div>
 
+<!-- Additional Options -->
+<div
+ng-class="{'loading': loading}"
+class="ui green segment">
+
+  <div class="ui header">
+    Additional Options
+  </div>
+
+  <div class="column">
+    <div class="ui buttons">
+        <button 
+          class="ui toggle button"
+          ng-class="{true: 'active', false: ''}[settings.allowMinors]"
+          ng-click="updateAllowMinors()">
+          Minors {{ settings.allowMinors && 'allowed' || 'disallowed' }}
+        </button>
+      </div>
+  </div>
+</div>
+
 <!-- Whitelist -->
 <div
   ng-class="{'loading': loading}"

--- a/app/client/views/admin/settings/settings.html
+++ b/app/client/views/admin/settings/settings.html
@@ -86,14 +86,21 @@ class="ui green segment">
   </div>
 
   <div class="column">
-    <div class="ui buttons">
-        <button 
-          class="ui toggle button"
-          ng-class="{true: 'active', false: ''}[settings.allowMinors]"
-          ng-click="updateAllowMinors()">
-          Minors {{ settings.allowMinors && 'allowed' || 'disallowed' }}
-        </button>
+    <div class="ui form">
+      <div class="grouped fields">
+        <div class="field">
+          <div class="ui toggle checkbox">
+              <input 
+              type="checkbox"
+              name="allowMinors"
+              ng-class="{true: 'checked', false: ''}[settings.allowMinors]"
+              ng-model="settings.allowMinors"
+              ng-change="updateAllowMinors()">
+              <label>Allow minors</label>
+          </div>
+        </div>
       </div>
+    </div>
   </div>
 </div>
 

--- a/app/client/views/application/applicationCtrl.js
+++ b/app/client/views/application/applicationCtrl.js
@@ -63,7 +63,28 @@ angular.module('reg')
           });
       }
 
+      function isMinor() {
+        return !$scope.user.profile.adult;
+      }
+
+      function minorsAreAllowed() {
+        return Settings.data.allowMinors;
+      }
+
+      function minorsValidation() {
+        // Are minors allowed to register?
+        if (isMinor() && !minorsAreAllowed()) {
+          return false;
+        }
+        return true;
+      }
+
       function _setupForm(){
+        // Custom minors validation rule
+        $.fn.form.settings.rules.allowMinors = function (value) {
+          return minorsValidation();
+        };
+
         // Semantic-UI form validation
         $('.ui.form').form({
           fields: {
@@ -107,7 +128,7 @@ angular.module('reg')
               identifier: 'adult',
               rules: [
                 {
-                  type: 'checked',
+                  type: 'allowMinors',
                   prompt: 'You must be an adult, or an MIT student.'
                 }
               ]

--- a/app/server/models/Settings.js
+++ b/app/server/models/Settings.js
@@ -37,6 +37,9 @@ var schema = new mongoose.Schema({
   confirmationText: {
     type: String
   },
+  allowMinors: {
+    type: Boolean
+  }
 });
 
 /**

--- a/app/server/routes/api.js
+++ b/app/server/routes/api.js
@@ -283,7 +283,8 @@ module.exports = function(router) {
    *   timeClose: Number,
    *   timeToConfirm: Number,
    *   acceptanceText: String,
-   *   confirmationText: String
+   *   confirmationText: String,
+   *   allowMinors: Boolean
    * }
    */
   router.get('/settings', function(req, res){
@@ -369,6 +370,19 @@ module.exports = function(router) {
   router.put('/settings/whitelist', isAdmin, function(req, res){
     var emails = req.body.emails;
     SettingsController.updateWhitelistedEmails(emails, defaultResponse(req, res));
+  });
+
+  /**
+   * [ADMIN ONLY]
+   * {
+   *   allowMinors: Boolean
+   * }
+   * res: Settings
+   *
+   */
+  router.put('/settings/minors', isAdmin, function(req, res){
+    var allowMinors = req.body.allowMinors;
+    SettingsController.updateField('allowMinors', allowMinors, defaultResponse(req, res));
   });
 
 };


### PR DESCRIPTION
Issue #15

I saw this issue up for grabs, and I'd like to make a contribution for Hacktoberfest.

I created an 'Additional Options' sections on the admin settings page and added a 'Allow minors' checkbox.

Toggling this checkbox will update a new boolean property called `allowMinors` in the server's Settings schema, and update the settings client side. A 'put' endpoint was added to the server api.js to allow changes to the `allowMinors` setting.

The client's applicationCtrl.js now checks the the `allowMinors` flag in the settings when doing the form validation for the 'adult' property in the user's profile.

I did my best to remain consistent with the codebase, and added as little as possible to get this working. Please don't hesitate to let me know if you'd like this done differently. Thanks!

Example Screenshots:

**Additional options section.**
**Minors set to disallowed.**

![image](https://user-images.githubusercontent.com/8728200/32129400-c7381a92-bb54-11e7-8be2-c55a4d415d01.png)

**This is what it looks like when toggled to 'allowed'.**

![image](https://user-images.githubusercontent.com/8728200/32129405-d51f1674-bb54-11e7-817f-750de1067d4b.png)

**This is the confirmation that pops up after you toggle the checkbox.**

![image](https://user-images.githubusercontent.com/8728200/32129414-ed37901a-bb54-11e7-8072-4c9a674e8583.png)
