### PR TITLE
Admin panel allow all emails option

### DIFF
--- a/app/client/src/services/SettingsService.js
+++ b/app/client/src/services/SettingsService.js
@@ -48,6 +48,11 @@ angular.module('reg')
           allowMinors: allowMinors 
         });
       },
+      updateAllowAllEmails: function(allowAllEmails){
+        return $http.put(base + 'allEmails', { 
+          allowAllEmails: allowAllEmails 
+        });
+      },
     };
 
   }

--- a/app/client/views/admin/settings/adminSettingsCtrl.js
+++ b/app/client/views/admin/settings/adminSettingsCtrl.js
@@ -36,6 +36,18 @@ angular.module('reg')
           });
       };
 
+      $scope.updateAllowAllEmails = function () {
+        SettingsService
+          .updateAllowAllEmails($scope.settings.allowAllEmails)
+          .success(function (data) {
+            $scope.settings.allowAllEmails = data.allowAllEmails;
+            const successText = $scope.settings.allowAllEmails ?
+              "All emails are now allowed to register." :
+              "Only whitelisted emails are now allowed to register."
+            swal("Looks good!", successText, "success");
+          });
+      };
+
       // Whitelist --------------------------------------
 
       SettingsService

--- a/app/client/views/admin/settings/settings.html
+++ b/app/client/views/admin/settings/settings.html
@@ -99,6 +99,17 @@ class="ui green segment">
               <label>Allow minors</label>
           </div>
         </div>
+        <div class="field">
+            <div class="ui toggle checkbox">
+                <input 
+                type="checkbox"
+                name="allowAllEmails"
+                ng-class="{true: 'checked', false: ''}[settings.allowAllEmails]"
+                ng-model="settings.allowAllEmails"
+                ng-change="updateAllowAllEmails()">
+                <label>Allow all emails</label>
+            </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/server/models/Settings.js
+++ b/app/server/models/Settings.js
@@ -39,6 +39,9 @@ var schema = new mongoose.Schema({
   },
   allowMinors: {
     type: Boolean
+  },
+  allowAllEmails: {
+    type: Boolean
   }
 });
 

--- a/app/server/routes/api.js
+++ b/app/server/routes/api.js
@@ -385,4 +385,17 @@ module.exports = function(router) {
     SettingsController.updateField('allowMinors', allowMinors, defaultResponse(req, res));
   });
 
+    /**
+   * [ADMIN ONLY]
+   * {
+   *   allowAllEmails: Boolean
+   * }
+   * res: Settings
+   *
+   */
+  router.put('/settings/allEmails', isAdmin, function(req, res){
+    var allowAllEmails = req.body.allowAllEmails;
+    SettingsController.updateField('allowAllEmails', allowAllEmails, defaultResponse(req, res));
+  });
+
 };


### PR DESCRIPTION
Issue #15
Closes #15

**This PR is dependent on #40,  since it builds on code in that PR.**

Making another contribution for Hacktoberfest, which completes #15.

I added a new checkbox called 'Allow all emails' to the 'Additional Options' section on the admin settings page.

Toggling this will update a new boolean property called `allowAllEmails` in the server's Settings schema,
and update the settings client side. A 'put' endpoint was added to the server api.js to allow changes to the `allowAllEmails` setting.

Upon new user registration, the UserController validation that occurs server side now checks the settings for `allowAllEmails` flag after validating that the email is a valid email type. If `allowAllEmails` is set to `true`, then the whitelist will not be checked for valid educational emails.

If the `allowAllEmails` flag is set to `false`, then the whitelist validation proceeds as normal.

I did my best to remain consistent with the codebase, and added as little as possible to get this working. Please don't hesitate to let me know if you'd like this done differently. Thanks!

Example Screenshots:

**Additional options section.**
**Allow all emails set to disallowed.**

![image](https://user-images.githubusercontent.com/8728200/32129453-68b2bff8-bb55-11e7-9cfc-2473a0525e67.png)

**This is what it looks like when toggled to 'allowed'.**

![image](https://user-images.githubusercontent.com/8728200/32129458-7920a3f0-bb55-11e7-906a-67dd757b82e8.png)

**This is the confirmation that pops up after you toggle the checkbox.**
![image](https://user-images.githubusercontent.com/8728200/32129468-9361c6ae-bb55-11e7-9017-4eeb21d912ab.png)