### PR TITLE
Add filters and queries for admin users #7

### DIFF
--- a/app/client/src/services/UserService.js
+++ b/app/client/src/services/UserService.js
@@ -24,12 +24,13 @@ angular.module('reg')
         return $http.get(base);
       },
 
-      getPage: function(page, size, text){
+      getPage: function(page, size, text, statusFilters){
         return $http.get(users + '?' + $.param(
           {
             text: text,
             page: page ? page : 0,
-            size: size ? size : 50
+            size: size ? size : 50,
+            statusFilters: statusFilters ? statusFilters : {}
           })
         );
       },

--- a/app/client/views/admin/users/adminUsersCtrl.js
+++ b/app/client/views/admin/users/adminUsersCtrl.js
@@ -33,18 +33,26 @@ angular.module('reg')
       }
 
       UserService
-        .getPage($stateParams.page, $stateParams.size, $stateParams.query)
+        .getPage($stateParams.page, $stateParams.size, $stateParams.query, $scope.statusFilters)
         .success(function(data){
           updatePage(data);
         });
 
       $scope.$watch('queryText', function(queryText){
         UserService
-          .getPage($stateParams.page, $stateParams.size, queryText)
+          .getPage($stateParams.page, $stateParams.size, queryText, $scope.statusFilters)
           .success(function(data){
             updatePage(data);
           });
       });
+
+      $scope.applyStatusFilter = function () {
+        UserService
+          .getPage($stateParams.page, $stateParams.size, $scope.queryText, $scope.statusFilters)
+          .success(function (data) {
+            updatePage(data);
+          });
+      };
 
       $scope.goToPage = function(page){
         $state.go('app.admin.users', {

--- a/app/client/views/admin/users/users.html
+++ b/app/client/views/admin/users/users.html
@@ -18,6 +18,81 @@
 
       </div>
 
+      <div class="ui form">
+        <div class="grouped fields">
+          <div class="field">
+              <div class="ui checkbox">
+                  <input 
+                  type="checkbox"
+                  name="completedProfile"
+                  ng-model="statusFilters.completedProfile"
+                  ng-change="applyStatusFilter()">
+                  <label>Completed Profile</label>
+              </div>
+          </div>
+          <div class="field">
+              <div class="ui checkbox">
+                  <input 
+                  type="checkbox"
+                  name="admitted"
+                  ng-model="statusFilters.admitted"
+                  ng-change="applyStatusFilter()">
+                  <label>Admitted</label>
+              </div>
+          </div>
+          <div class="field">
+              <div class="ui checkbox">
+                  <input 
+                  type="checkbox"
+                  name="confirmed"
+                  ng-model="statusFilters.confirmed"
+                  ng-change="applyStatusFilter()">
+                  <label>Confirmed</label>
+              </div>
+          </div>
+          <div class="field">
+              <div class="ui checkbox">
+                  <input 
+                  type="checkbox"
+                  name="declined"
+                  ng-model="statusFilters.declined"
+                  ng-change="applyStatusFilter()">
+                  <label>Declined</label>
+              </div>
+          </div>
+          <div class="field">
+              <div class="ui checkbox">
+                  <input 
+                  type="checkbox"
+                  name="checkedIn"
+                  ng-model="statusFilters.checkedIn"
+                  ng-change="applyStatusFilter()">
+                  <label>Checked In</label>
+              </div>
+          </div>
+          <div class="field">
+              <div class="ui checkbox">
+                  <input 
+                  type="checkbox"
+                  name="reimbursementGiven"
+                  ng-model="statusFilters.reimbursementGiven"
+                  ng-change="applyStatusFilter()">
+                  <label>Reimbursement Given</label>
+              </div>
+          </div>
+          <div class="field">
+              <div class="ui checkbox">
+                  <input 
+                  type="checkbox"
+                  name="verified"
+                  ng-model="statusFilters.verified"
+                  ng-change="applyStatusFilter()">
+                  <label>Verified</label>
+              </div>
+          </div>
+        </div>
+      </div>
+
       <div class="ui divider"></div>
 
       <button

--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -210,6 +210,74 @@ UserController.getAll = function (callback) {
 };
 
 /**
+ * Builds search text queries.
+ * 
+ * @param   {String} searchText the text to search
+ * @returns {Object} queries    text queries
+ */
+function buildTextQueries(searchText) {
+  const queries = [];
+  if (searchText.length > 0) {
+    const re = new RegExp(searchText, 'i');
+    queries.push({ 'email': re });
+    queries.push({ 'profile.name': re });
+    queries.push({ 'teamCode': re });
+  }
+  return queries;
+}
+
+/**
+ * Builds status queries.
+ * Each key on 'statusFilters' is a status, and the value is a bool.
+ * 
+ * @param   {[type]} statusFilters object with status keys
+ * @returns {Object} queries  status queries
+ */
+function buildStatusQueries(statusFilters) {
+  const queries = [];
+  for (var key in statusFilters) {
+    if (statusFilters.hasOwnProperty(key)) {
+      // Convert to boolean
+      const hasStatus = (statusFilters[key] === 'true');
+      if (hasStatus) {
+        var q = {};
+        // Verified is a prop on user object
+        var queryKey = (key === 'verified' ? key : 'status.' + key);
+        q[queryKey] = true;
+        queries.push(q);
+      }
+    }
+  }
+  return queries;
+}
+
+/**
+ * Builds a find query.
+ * The root changes according to the following:
+ * $and { $or, $and } for text and status queries respectively
+ * $or for text queries
+ * $and for status queries
+ * 
+ * @param   {[type]} textQueries   text query objects
+ * @param   {[type]} statusQueries size of the page
+ * @returns {Object} findQuery     query object
+ */
+function buildFindQuery(textQueries, statusQueries) {
+  const findQuery = {};
+  if (textQueries.length > 0 && statusQueries.length > 0) {
+    var queryRoot = [];
+    queryRoot.push({ '$or': textQueries });
+    queryRoot.push({ '$and': statusQueries });
+    findQuery.$and = queryRoot;
+  } else if (textQueries.length > 0) {
+    findQuery.$or = textQueries;
+  } else if (statusQueries.length > 0) {
+    findQuery.$and = statusQueries;
+  }
+  return findQuery;
+}
+
+/**
  * Get a page of users.
  * @param  {[type]}   page     page number
  * @param  {[type]}   size     size of the page
@@ -219,17 +287,16 @@ UserController.getPage = function(query, callback){
   var page = query.page;
   var size = parseInt(query.size);
   var searchText = query.text;
+  var statusFilters = query.statusFilters;
 
-  var findQuery = {};
-  if (searchText.length > 0){
-    var queries = [];
-    var re = new RegExp(searchText, 'i');
-    queries.push({ email: re });
-    queries.push({ 'profile.name': re });
-    queries.push({ 'teamCode': re });
+  // Build a query for the search text
+  var textQueries = buildTextQueries(searchText);
 
-    findQuery.$or = queries;
-  }
+  // Build a query for each status
+  var statusQueries = buildStatusQueries(statusFilters);
+
+  // Build find query
+  var findQuery = buildFindQuery(textQueries, statusQueries);
 
   User
     .find(findQuery)


### PR DESCRIPTION
Issue #7 
Closes #7 

Another Hacktoberfest contribution.

I'm open to suggestions for the UX for this, but here's a first pass.
Added filter checkboxes for each of the `user.status` fields (and `user.verified`).

Applying more filters makes the search more restrictive (i.e only show users that have all checked statuses).

The filters work in combination with the search text.
If no text in specified, the status filters work standalone.
If text is specified, then it further restricts based on matching text.

Examples:
text: `.edu`
statusFilters : `{ 'confirmed' : true, 'admitted': false }`

This will only show users that have a .edu email **and** have been confirmed.

If the filters are not used, the search functionality remains unchanged.

If you have any suggestions on the UX or the way the algorithm was implemented, please let me know and I'll do my best to improve the feature!

I didn't touch pagination, since I believe that is a separate issue. 
Thanks!

Example screenshot:

![image](https://user-images.githubusercontent.com/8728200/32130574-c80e0d82-bb68-11e7-99c0-07eacea4dd9b.png)
