### PR TITLE
Force lower-case email instead of using regex

### DIFF
--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -406,7 +406,7 @@ UserController.declineById = function (id, callback){
 UserController.verifyByToken = function(token, callback){
   User.verifyEmailVerificationToken(token, function(err, email){
     User.findOneAndUpdate({
-      email: new RegExp('^' + email + '$', 'i')
+      email: email.toLowerCase()
     },{
       $set: {
         'verified': true

--- a/app/server/models/User.js
+++ b/app/server/models/User.js
@@ -309,7 +309,7 @@ schema.statics.verifyTempAuthToken = function(token, callback){
 
 schema.statics.findOneByEmail = function(email){
   return this.findOne({
-    email: new RegExp('^' + email + '$', 'i')
+    email: email.toLowerCase()
   });
 };
 


### PR DESCRIPTION
Since emails are recorded in [lowercase](https://github.com/techx/quill/blob/83c10c1df051beb50175eae71dd5e480fe25690e/app/server/controllers/UserController.js#L144), we can search for lowercased emails. This fixes bugs for users with regex in their emails (test+1@gmail.com)