### PR TITLE
Fix Note covering links on sidebar

### DIFF
--- a/app/client/stylesheets/_sidebar.scss
+++ b/app/client/stylesheets/_sidebar.scss
@@ -44,11 +44,9 @@
     font-size: .8em;
     text-align: center;
     padding: 16px;
-    position: absolute;
     left: 0;
     right: 0;
     bottom: 16px;
-
   }
 
   // Tab is the sibling of the sidebar
@@ -103,9 +101,5 @@
       @include transform(translate3d(0,0,0));
       padding: 12px;
     }
-    .note {
-      display: none;
-    }
-
   }
 }


### PR DESCRIPTION
On smaller displays, sometimes the note can cover up necessary links, so
this change removes position absolute so that it will go to the bottom
of the list of links. This change also makes the note visible on mobile.