### PR TITLE
Replaced color palette with Bitcamp colors

### DIFF
--- a/app/client/stylesheets/_custom.scss
+++ b/app/client/stylesheets/_custom.scss
@@ -1,3 +1,12 @@
 // Branding overrides
 //
 // Copy variables from `_branding.scss` to this file to override default values.
+
+/** BRANDING COLORS
+ * primary (Midnight Blue): sidebar color, admitted dashboard status
+ * secondary (Flame Red): header text, submitted/confirmed/checked-in dashboard status
+ * tertiary (Medium Blue): waitlist/declined dashboard status
+ */
+$primary: #1A2E33;
+$secondary: #FF3F46;
+$tertiary: #528CA5;


### PR DESCRIPTION
Please note, the button is still purple because the Quill app uses semantic-ui for their buttons and stuff. Not sure how to override them at the moment as I cannot deploy locally due to problems.

Please test this update before merging, but I suspect it should be fine because it's just a few hex colors lol.

Theoretically, the app should now look like this:
![expired](https://user-images.githubusercontent.com/18043276/35492542-7da33c48-047b-11e8-9908-782f7b6638d7.jpg)
![incomplete](https://user-images.githubusercontent.com/18043276/35492543-7db0c868-047b-11e8-97cc-03b0ceb0639f.jpg)
