### PR TITLE
Fix build errors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "JAFRS",
+  "name": "jafrs",
   "version": "0.0.0",
   "homepage": "https://github.com/techx/hackmit-registration",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-minify-css": "^1.2.0",
     "gulp-ng-annotate": "^1.1.0",
     "gulp-nodemon": "^2.2.1",
-    "gulp-sass": "^2.3.2",
+    "gulp-sass": "3.0.0",
     "gulp-sourcemaps": "^1.12.0",
     "gulp-uglify": "^1.5.4",
     "handlebars": "^4.0.11",


### PR DESCRIPTION
The older package of gulp-sass was creating some errors on installation, hence I updated its version.

On running bower install, it creates an error saying the name should be in small case, hence I made it lowercase