### PR TITLE
Add Docker functionality to Quill

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+db/
+node_modules/
+app/client/build/
+app/client/plugins/
+*.log
+.env
+package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:8
+
+WORKDIR /usr/app/src
+
+# Load Source
+COPY . .
+
+# Install Bower
+RUN npm install -g bower
+# Install Gulp
+RUN npm install -g gulp
+
+# Install node_modules
+RUN npm install
+
+# Install bower dependencies
+RUN bower --allow-root install
+
+# Build Using Gulp
+RUN gulp build
+
+CMD node app.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '2'
+services:
+  web:
+    restart: always
+    build: .
+    container_name: quill
+    ports:
+     - "3000:3000"
+     - "5858:5858"
+     - "8080:8080"
+     - "35729:35729"
+    environment:
+     - NODE_ENV=dev
+     - DATABASE=db
+     - PORT=3000
+     - JWT_SECRET=shhhh super secret code here bro
+     - ROOT_URL=http://localhost:3000
+     - ADMIN_EMAIL=admin@example.com
+     - ADMIN_PASS=party
+     - EMAIL_CONTACT=Hackathon Team <team@example.com>
+     - EMAIL_HOST=smtp.example.com
+     - EMAIL_USER=no-reply@example.com
+     - EMAIL_PASS=password
+     - EMAIL_PORT=465
+     - EMAIL_HEADER_IMAGE=https://s3.amazonaws.com/hackmit-assets/Banner_600.jpg
+    depends_on:
+     - db
+    volumes_from:
+     - web-data
+  web-data:
+    build: .
+    entrypoint: /bin/true
+    volumes:
+     - ./:/opt/mean.js
+     - /opt/mean.js/node_modules
+     - /opt/mean.js/public
+     - /opt/mean.js/uploads
+  db:
+    image: mongo:3.2
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes_from:
+      - db-data
+  db-data:
+    image: mongo:3.2
+    volumes:
+      - /data/db
+      - /var/lib/mongodb
+      - /var/log/mongodb
+    entrypoint: /bin/true


### PR DESCRIPTION
I've added a Dockerfile and .dockerignore for quill, as well as a docker-compose.yml file for 'one-click' deployment alongside MongoDB.