### PR TITLE
Add automatic admittance emails after admitting users

### DIFF
--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -630,7 +630,7 @@ UserController.resetPassword = function(token, password, callback){
  * [ADMIN ONLY]
  *
  * Admit a user.
- * @param  {String}   userId   User id of the admit
+ * @param  {String}   id   User id of the admit
  * @param  {String}   user     User doing the admitting
  * @param  {Function} callback args(err, user)
  */
@@ -650,6 +650,17 @@ UserController.admitUser = function(id, user, callback){
         new: true
       },
       callback);
+
+    //Find the user by the ID and send him an email
+    User.findOne({
+        _id: id
+      },
+      function(err, user){
+        if (err || !user){
+          return callback(err);
+        }
+      Mailer.sendConfirmationEmail(user.email);
+    });
   });
 };
 

--- a/app/server/services/email.js
+++ b/app/server/services/email.js
@@ -97,7 +97,7 @@ controller.sendVerificationEmail = function(email, token, callback) {
   };
 
   /**
-   * Eamil-verify takes a few template values:
+   * Email-verify takes a few template values:
    * {
    *   verifyUrl: the url that the user must visit to verify their account
    * }
@@ -114,6 +114,33 @@ controller.sendVerificationEmail = function(email, token, callback) {
     }
   });
 
+};
+
+controller.sendConfirmationEmail = function(email, callback) {
+  var options = {
+    to: email,
+    subject: "["+HACKATHON_NAME+"] - You've been admitted!"
+  };
+
+  var locals = {
+    title: 'Congrats! You\'ve been admitted to ' + HACKATHON_NAME + '!',
+    subtitle: '',
+    description: 'Please make sure you confirm your application by clicking the button below.',
+    actionUrl: ROOT_URL + '/confirmation',
+    actionName: 'Confirm Application'
+  };
+
+  sendOne('email-link-action', options, locals, function(err, info) {
+    if (err){
+      console.log(err);
+    }
+    if (info){
+      console.log(info.message);
+    }
+    if (callback){
+      callback(err, info);
+    }
+  });
 };
 
 /**
@@ -139,7 +166,7 @@ controller.sendPasswordResetEmail = function(email, token, callback) {
   };
 
   /**
-   * Eamil-verify takes a few template values:
+   * Email-verify takes a few template values:
    * {
    *   verifyUrl: the url that the user must visit to verify their account
    * }
@@ -176,7 +203,7 @@ controller.sendPasswordChangedEmail = function(email, callback){
   };
 
   /**
-   * Eamil-verify takes a few template values:
+   * Email-verify takes a few template values:
    * {
    *   verifyUrl: the url that the user must visit to verify their account
    * }


### PR DESCRIPTION
# Description
When an admin admits users in the admin page, the application sends an automatic email to the admittees notifying them that they have been admitted to hackathon and that they should continue to the confirmation stage.

## Motivation and Context
Before this PR, there was no way for the users to know that they have been admitted, unless they constantly checked their application status, or the admin has manually sent them an email notifying them about their application state.
This PR solves this issue by automatically sending an admittance email, notifying the participant that he/she has been admitted.

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
Was at first tested locally using a real email and gmail's smtp server.
Once tested thoroughly locally, this improvement was added to mtahack's fork (mtahack/quill@919fa1e15168291a5b15c2a9e6f23c70575aad58) and worked without any bugs for 120 participants.

<!--- Include details of your testing environment, and the tests you ran to -->
Tested on macOS and Windows locally.
Tested on Heroku.
Works even after confirming a user many times.

## Screenshots
Screenshot of the confirmation email (with .env settings set to MTA Hack 2021)
![Screen Shot 2021-04-21 at 21 02 47](https://user-images.githubusercontent.com/53123142/115600191-15b00600-a2e5-11eb-840e-990641da74f6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

Also, fixed some spelling mistakes in the comments.
